### PR TITLE
Improve syntax of embedded YAML file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,7 @@ language: php
 php:
   - '5.6'
 install: composer install
-script: ./vendor/bin/phpcs $(git diff --name-only HEAD~1 | grep '\.php$')
+script:
+  - >-
+      ./vendor/bin/phpcs
+      $(git diff --name-only HEAD~1 | grep '\.php$')

--- a/README.md
+++ b/README.md
@@ -55,13 +55,15 @@ php:
   - '5.6'
 install: composer install
 script:
-  - ./vendor/bin/phpcs
-    --ruleset=SilverorangeTransitional
-    --tab-width=4
-    --encoding=utf-8
-    --warning-severity=0
-    --extensions=php
-    $(git diff --name-only HEAD~1 | grep '\.php$')
+  - >-
+      ./vendor/bin/phpcs
+      --ruleset=SilverorangeTransitional
+      --tab-width=4
+      --encoding=utf-8
+      --warning-severity=0
+      --extensions=php
+      $(git diff --name-only HEAD~1 | grep '\.php$')
+---
 ```
 
 Rulesets


### PR DESCRIPTION
Atom can syntax highlight this version properly. This uses YAML multi-line folded strings that strip whitespace.

The syntax can be checked with http://yaml-online-parser.appspot.com/

The updated version uses folded block literal syntax http://yaml.org/spec/1.2/spec.html#id2796251 with the `strip` chomping operator http://yaml.org/spec/1.2/spec.html#id2794534

An end-of-directives marker (`---`) is added only to aid syntax highlighting in code editors. It is not necessary but also causes no issues and is valid YAML.