### PR TITLE
Allow object operators to be on new lines

### DIFF
--- a/src/SilverorangeLegacy/ruleset.xml
+++ b/src/SilverorangeLegacy/ruleset.xml
@@ -129,7 +129,11 @@
   </rule>
   <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
   <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
-  <rule ref="Squiz.WhiteSpace.ObjectOperatorSpacing"/>
+  <rule ref="Squiz.WhiteSpace.ObjectOperatorSpacing">
+    <properties>
+      <property name="ignoreNewlines" type="boolean" value="true" />
+    </properties>
+  </rule>
   <rule ref="Squiz.WhiteSpace.ScopeClosingBrace"/>
   <rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing"/>
   <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>


### PR DESCRIPTION
Stuff like this https://github.com/silverorange/Rap/blob/master/Rap/RapShippingLabelsDescriptor.php#L74 will no longer be marked as an error