### PR TITLE
Standardize function declaration more

### DIFF
--- a/src/SilverorangeLegacy/ruleset.xml
+++ b/src/SilverorangeLegacy/ruleset.xml
@@ -96,8 +96,7 @@
 
   <rule ref="Squiz.Functions.FunctionDuplicateArgument"/>
   <rule ref="Squiz.Functions.FunctionDeclaration"/>
-  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine"/>
-  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.NewlineBeforeOpenBrace"/>
+  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration"/>
 
   <rule ref="Squiz.Operators.ValidLogicalOperators"/>
 


### PR DESCRIPTION
Having just the two specific sniffs for multiline function declaration was better, but it did lead to some strange scenarios like allowing this

```
public function doThing($arg1, $arg2,
    $arg3, $arg4) {
```

to be valid syntax. Enforcing these extra rules conforms the standard to either:
A)A single line declaration, with all arguments existing on the same line as the `function` keyword, with the opening brace on a new line,
or B)A multiline declaration, with each argument existing on its own line, and the closing parentheses and open brackets each on a new line together `) {`.