### PR TITLE
Fix allowing empty-catch statements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }
   ],
   "require": {
-    "squizlabs/php_codesniffer": "^3.0.0"
+    "squizlabs/php_codesniffer": "^3.2.3"
   },
   "autoload": {
     "psr-4": { "silverorange\\CodingStandard\\" : "src/" }

--- a/src/SilverorangeLegacy/ruleset.xml
+++ b/src/SilverorangeLegacy/ruleset.xml
@@ -90,7 +90,7 @@
   <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
 
   <!-- We allow empty catch statements -->
-  <rule ref="Generic.CodeAnalysis.EmptyStatement.DetectedCATCH">
+  <rule ref="Generic.CodeAnalysis.EmptyStatement.DetectedCatch">
     <severity>0</severity>
   </rule>
 


### PR DESCRIPTION
See https://github.com/squizlabs/PHP_CodeSniffer/issues/1909. It may not make sense to merge this.

Update: Maintainer says the rule name change will remain so this is good to merge.