### PR TITLE
Update prettier standard to allow prettier to wrap long default method arguments

### DIFF
--- a/src/SilverorangePrettier/ruleset.xml
+++ b/src/SilverorangePrettier/ruleset.xml
@@ -9,6 +9,15 @@
     <severity>0</severity>
   </rule>
 
+  <!-- Required for prettier formatting. Allows breaking default argument
+       assignment across multiple lines. -->
+  <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceAfterEquals">
+    <severity>0</severity>
+  </rule>
+  <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.Indent">
+    <severity>0</severity>
+  </rule>
+
   <rule ref="Generic.Classes.DuplicateClassName"/>
 
   <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>


### PR DESCRIPTION
Allows this to be valid:

```php
    public function getISO8601(
        $options =
            self::ISO_EXTENDED | self::ISO_MICROTIME | self::ISO_TIME_ZONE,
    ): string {
        ...
    }
```